### PR TITLE
Add critical alert option to authorization request

### DIFF
--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -219,6 +219,9 @@
                 authorizationOptions |= UNAuthorizationOptionAlert;
             }
 
+            // Specifically for RMA, always add critical alert option on authorization request
+            authorizationOptions |= UNAuthorizationOptionCriticalAlert;
+
             if (clearBadgeArg == nil || ([clearBadgeArg isKindOfClass:[NSString class]] && [clearBadgeArg isEqualToString:@"false"]) || ![clearBadgeArg boolValue]) {
                 NSLog(@"PushPlugin.register: setting badge to false");
                 clearBadge = NO;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adding the critical alert option when requesting for push notification authorization.

NOTE: This is specifically only for RMA, this changes **MIGHT** not suitable if being reused for other application.

## JIRA
https://ischemaview.atlassian.net/browse/CLOUD-4859
