### PR TITLE
[CLOUD-5962] OS handling of foreground notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 
-## [v3.3.0]\[FORKED\](https://github.com/ischemaview/phonegap-plugin-push/tree/v3.3.0) (2022-12-14)
+## [v3.4.0](https://github.com/ischemaview/phonegap-plugin-push/tree/v3.4.0) (2023-02-25)
+* Bypass foreground check for silent push notifications [view commit](https://github.com/ischemaview/phonegap-plugin-push/commit/a9b440663e45002ededff4a8dd466a478f068c10)
+
+## [v3.3.0 \[FORKED\]](https://github.com/ischemaview/phonegap-plugin-push/tree/v3.3.0) (2022-12-14)
 * Updates for Android API 31+ and cordova-android@11
 
 ## [v2.2.0](https://github.com/phonegap/phonegap-plugin-push/tree/v2.2.0) (2017-10-23)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ischemaview-phonegap-plugin-push",
-  "version": "3.4.0",
+  "version": "3.4.1-foreground.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ischemaview-phonegap-plugin-push",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ischemaview-phonegap-plugin-push",
   "description": "Register and receive push notifications. Forked to add functionality by iSchemaView",
   "types": "./types/index.d.ts",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "homepage": "https://github.com/ischemaview/cordova-plugin-background-download#readme",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ischemaview-phonegap-plugin-push",
   "description": "Register and receive push notifications. Forked to add functionality by iSchemaView",
   "types": "./types/index.d.ts",
-  "version": "3.4.1-foreground.0",
+  "version": "3.4.0",
   "homepage": "https://github.com/ischemaview/cordova-plugin-background-download#readme",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ischemaview-phonegap-plugin-push",
   "description": "Register and receive push notifications. Forked to add functionality by iSchemaView",
   "types": "./types/index.d.ts",
-  "version": "3.4.0",
+  "version": "3.4.1-foreground.0",
   "homepage": "https://github.com/ischemaview/cordova-plugin-background-download#readme",
   "repository": {
     "type": "git",

--- a/src/android/com/adobe/phonegap/push/FCMService.java
+++ b/src/android/com/adobe/phonegap/push/FCMService.java
@@ -75,6 +75,7 @@ public class FCMService extends FirebaseMessagingService implements PushConstant
 
     String from = message.getFrom();
     Log.d(LOG_TAG, "onMessage - from: " + from);
+    Log.d(LOG_TAG, "message ---> " + message);
 
     Bundle extras = new Bundle();
 
@@ -94,10 +95,12 @@ public class FCMService extends FirebaseMessagingService implements PushConstant
 
       SharedPreferences prefs = applicationContext.getSharedPreferences(PushPlugin.COM_ADOBE_PHONEGAP_PUSH,
           Context.MODE_PRIVATE);
-      boolean forceShow = prefs.getBoolean(FORCE_SHOW, false);
+      boolean forceShow = prefs.getBoolean(FORCE_SHOW, true);
       boolean clearBadge = prefs.getBoolean(CLEAR_BADGE, false);
       String messageKey = prefs.getString(MESSAGE_KEY, MESSAGE);
       String titleKey = prefs.getString(TITLE_KEY, TITLE);
+
+      Log.d(LOG_TAG, "forceShow ---> " + forceShow);
 
       extras = normalizeExtras(applicationContext, extras, messageKey, titleKey);
 
@@ -344,6 +347,8 @@ public class FCMService extends FirebaseMessagingService implements PushConstant
     if ((message != null && message.length() != 0) || (title != null && title.length() != 0)) {
 
       Log.d(LOG_TAG, "create notification");
+      Log.d(LOG_TAG, "context ---> " + context);
+      Log.d(LOG_TAG, "extras ---> " + extras);
 
       if (title == null || title.isEmpty()) {
         extras.putString(TITLE, getAppName(this));

--- a/src/android/com/adobe/phonegap/push/FCMService.java
+++ b/src/android/com/adobe/phonegap/push/FCMService.java
@@ -75,7 +75,6 @@ public class FCMService extends FirebaseMessagingService implements PushConstant
 
     String from = message.getFrom();
     Log.d(LOG_TAG, "onMessage - from: " + from);
-    Log.d(LOG_TAG, "message ---> " + message);
 
     Bundle extras = new Bundle();
 
@@ -99,8 +98,6 @@ public class FCMService extends FirebaseMessagingService implements PushConstant
       boolean clearBadge = prefs.getBoolean(CLEAR_BADGE, false);
       String messageKey = prefs.getString(MESSAGE_KEY, MESSAGE);
       String titleKey = prefs.getString(TITLE_KEY, TITLE);
-
-      Log.d(LOG_TAG, "forceShow ---> " + forceShow);
 
       extras = normalizeExtras(applicationContext, extras, messageKey, titleKey);
 
@@ -347,8 +344,6 @@ public class FCMService extends FirebaseMessagingService implements PushConstant
     if ((message != null && message.length() != 0) || (title != null && title.length() != 0)) {
 
       Log.d(LOG_TAG, "create notification");
-      Log.d(LOG_TAG, "context ---> " + context);
-      Log.d(LOG_TAG, "extras ---> " + extras);
 
       if (title == null || title.isEmpty()) {
         extras.putString(TITLE, getAppName(this));

--- a/src/ios/AppDelegate+notification.m
+++ b/src/ios/AppDelegate+notification.m
@@ -190,14 +190,7 @@ NSString *const pushPluginApplicationDidBecomeActiveNotification = @"pushPluginA
          withCompletionHandler:(void (^)(UNNotificationPresentationOptions options))completionHandler
 {
     NSLog( @"NotificationCenter Handle push from foreground" );
-    // custom code to handle push while app is in the foreground
-    PushPlugin *pushHandler = [self getCommandInstance:@"PushNotification"];
-    pushHandler.notificationMessage = notification.request.content.userInfo;
-    pushHandler.isInline = YES;
-    [pushHandler notificationReceived];
-
     UNNotificationPresentationOptions presentationOptions = UNNotificationPresentationOptionSound | UNNotificationPresentationOptionBadge | UNNotificationPresentationOptionList | UNNotificationPresentationOptionBanner;
-
     completionHandler(presentationOptions);
 }
 
@@ -208,7 +201,10 @@ didReceiveNotificationResponse:(UNNotificationResponse *)response
     NSLog(@"Push Plugin didReceiveNotificationResponse: actionIdentifier %@, notification: %@", response.actionIdentifier,
           response.notification.request.content.userInfo);
     NSMutableDictionary *userInfo = [response.notification.request.content.userInfo mutableCopy];
-    [userInfo setObject:response.actionIdentifier forKey:@"actionCallback"];
+    
+    if (![response.actionIdentifier isEqualToString: UNNotificationDefaultActionIdentifier]) {
+        [userInfo setObject:response.actionIdentifier forKey:@"actionCallback"];
+    }
     NSLog(@"Push Plugin userInfo %@", userInfo);
 
     switch ([UIApplication sharedApplication].applicationState) {

--- a/src/ios/AppDelegate+notification.m
+++ b/src/ios/AppDelegate+notification.m
@@ -196,7 +196,9 @@ NSString *const pushPluginApplicationDidBecomeActiveNotification = @"pushPluginA
     pushHandler.isInline = YES;
     [pushHandler notificationReceived];
 
-    completionHandler(UNNotificationPresentationOptionNone);
+    UNNotificationPresentationOptions presentationOptions = UNNotificationPresentationOptionSound | UNNotificationPresentationOptionBadge | UNNotificationPresentationOptionList | UNNotificationPresentationOptionBanner;
+
+    completionHandler(presentationOptions);
 }
 
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center

--- a/src/ios/AppDelegate+notification.m
+++ b/src/ios/AppDelegate+notification.m
@@ -201,7 +201,13 @@ didReceiveNotificationResponse:(UNNotificationResponse *)response
     NSLog(@"Push Plugin didReceiveNotificationResponse: actionIdentifier %@, notification: %@", response.actionIdentifier,
           response.notification.request.content.userInfo);
     NSMutableDictionary *userInfo = [response.notification.request.content.userInfo mutableCopy];
-    
+
+    /// The Push plugin pipe events using few identifiers, the default ones are `register` and `notification`.
+    /// Typically, push notification of any kind would go through `notification` events on javascript side.
+    /// However, when `actionCallback` is set, javascript side uses the value of that key for the identifier of the events pipe.
+    /// Existing behavior of tapping notification banner when app backgrounded is nil `actionIdentifier`.
+    /// Unfortunately, when banner is tapped on foreground, iOS sets the `actionIdentifier` to `UNNotificationDefaultActionIdentifier`.
+    /// To replicate that behavior when app is foregrounded, we avoid setting `actionIdentifier` so that it pipes through the `notification` events on javascript side.
     if (![response.actionIdentifier isEqualToString: UNNotificationDefaultActionIdentifier]) {
         [userInfo setObject:response.actionIdentifier forKey:@"actionCallback"];
     }


### PR DESCRIPTION
Changes to instruct OS to handle foreground notification

## Description
### Android
- Now passing forceShow true when initializing the PushPlugin in the app

### iOS
- In `willPresentNotification` removed instructions to handle as notificationReceived
- In `willPresentNotification` changed completionHandler options with instructions for iOS to handle
- In `didReceiveNotificationResponse` added logic to only add actionCallback if actionIdentifier is not UNNotificationDefaultActionIdentifier

## Related Issue
- [JIRA ticket CLOUD-5962](https://ischemaview.atlassian.net/browse/CLOUD-5962)

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

