### PR TITLE
[CLOUD-5962] add back logic to trigger on('notification')  

### DIFF
--- a/src/android/com/adobe/phonegap/push/FCMService.java
+++ b/src/android/com/adobe/phonegap/push/FCMService.java
@@ -118,6 +118,7 @@ public class FCMService extends FirebaseMessagingService implements PushConstant
         extras.putBoolean(FOREGROUND, true);
         extras.putBoolean(COLDSTART, false);
 
+        PushPlugin.sendExtras(extras);
         showNotificationIfPossible(applicationContext, extras);
       }
       // if we are not in the foreground always send notification if the data has at least a message or title

--- a/src/ios/AppDelegate+notification.m
+++ b/src/ios/AppDelegate+notification.m
@@ -190,6 +190,12 @@ NSString *const pushPluginApplicationDidBecomeActiveNotification = @"pushPluginA
          withCompletionHandler:(void (^)(UNNotificationPresentationOptions options))completionHandler
 {
     NSLog( @"NotificationCenter Handle push from foreground" );
+
+    PushPlugin *pushHandler = [self getCommandInstance:@"PushNotification"];
+    pushHandler.notificationMessage = notification.request.content.userInfo;
+    pushHandler.isInline = YES;
+    [pushHandler notificationReceived];
+
     UNNotificationPresentationOptions presentationOptions = UNNotificationPresentationOptionSound | UNNotificationPresentationOptionBadge | UNNotificationPresentationOptionList | UNNotificationPresentationOptionBanner;
     completionHandler(presentationOptions);
 }


### PR DESCRIPTION
## Description
- Add back iOS logic to trigger JS side on('notification') event when foreground notification is received and tapped. The app uses the receipt of the foreground notification for data fetching.